### PR TITLE
Fix dag.multihash usage

### DIFF
--- a/src/db-manifest.js
+++ b/src/db-manifest.js
@@ -12,7 +12,7 @@ const createDBManifest = (name, type, accessControllerAddress, publicKey) => {
 
 const uploadDBManifest = async (ipfs, manifest) => {
   const dag = await ipfs.object.put(encodeManifest(manifest))
-  return dag.toJSON().multihash.toString()
+  return dag.toJSON().hash.toString()
 }
 
 const signDBManifest = async (manifest, identity, identityProvider) => {

--- a/src/ipfs-access-controller.js
+++ b/src/ipfs-access-controller.js
@@ -34,15 +34,14 @@ class IPFSAccessController extends AbstractAccessController {
   }
 
   async save () {
-    let hash
     try {
       const access = JSON.stringify(this._access, null, 2)
       const dag = await this._ipfs.object.put(new Buffer(access))
-      hash = dag.toJSON().multihash.toString()
+      const hash = dag.toJSON().hash.toString()
+      return path.join('/ipfs', hash)
     } catch (e) {
       console.log("ACCESS ERROR:", e)
     }
-    return path.join('/ipfs', hash)
   }
 
   async setup ({ accessControllerAddress: address }) {


### PR DESCRIPTION
I noticed some issues with the usage of dag.multihash.

This line is wrong: https://github.com/JoinColony/orbit-db/blob/73a67d9d8a509f325d06f69cbde1bc7f18617f4c/src/ipfs-access-controller.js#L41

It should be `hash` not `multihash`: https://github.com/multiformats/js-cid/blob/22504757cead5e3213d6fd4a385ab546885debe8/src/index.js#L221. Also it's already a string.

I found the same issue in `db-manifest.json`

Furthermore the error handling in the `save` function was a little off. I hope it's a bit better now.