### PR TITLE
Embed manifest signature into manifest object

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -269,11 +269,11 @@ class OrbitDB {
 
     // Save the manifest to IPFS
     const manifest = createDBManifest(name, type, accessControllerAddress, this.identity.publicKey)
-    const manifestHash = await uploadDBManifest(this._ipfs, manifest)
+    const signature = await signDBManifest(manifest, this.identity, this.identity.provider)
+    const manifestHash = await uploadDBManifest(this._ipfs, manifest, signature)
 
     // Create the database address
-    const manifestSignature = await signDBManifest(manifest, this.identity, this.identity.provider)
-    const dbAddress = OrbitDBAddress.parse(path.join('/orbitdb', manifestHash, name, manifestSignature))
+    const dbAddress = OrbitDBAddress.parse(path.join('/orbitdb', manifestHash, name))
 
     // Load local cache
     const haveDB = await this._loadCache(directory, dbAddress)
@@ -348,7 +348,7 @@ class OrbitDB {
     const manifest = JSON.parse(dag.toJSON().data)
     logger.debug(`Manifest for '${dbAddress}':\n${JSON.stringify(manifest, null, 2)}`)
 
-    const isValid = await verifyDBManifest(manifest, dbAddress.signature, this.identity.provider)
+    const isValid = await verifyDBManifest(manifest, this.identity.provider)
     if (!isValid) {
       throw new Error(`Could not verify ${dbAddress}`)
     }
@@ -397,11 +397,11 @@ class OrbitDB {
     const accessControllerAddress = await accessController.save({ onlyHash: true })
 
     const manifest = createDBManifest(name, type, accessControllerAddress, this.identity.publicKey)
-    const manifestSignature = await signDBManifest(manifest, this.identity, this.identity.provider)
-    const manifestHash = await getManifestHash(manifest)
+    const signature = await signDBManifest(manifest, this.identity, this.identity.provider)
+    const manifestHash = await getManifestHash(manifest, signature)
 
     // Create the database address
-    return OrbitDBAddress.parse(path.join('/orbitdb', manifestHash, name, manifestSignature))
+    return OrbitDBAddress.parse(path.join('/orbitdb', manifestHash, name))
   }
 
   // Save the database locally

--- a/src/db-manifest.js
+++ b/src/db-manifest.js
@@ -19,13 +19,15 @@ const createDBManifest = (name, type, accessControllerAddress, publicKey) => {
   }
 }
 
-const getManifestHash = async (manifest) => {
-  const dag = await createDAGNode(encodeManifest(manifest))
+const getManifestHash = async (manifest, signature) => {
+  const signedManifest = Object.assign({}, manifest, { signature })
+  const dag = await createDAGNode(encodeManifest(signedManifest))
   return dag.toJSON().multihash.toString()
 }
 
-const uploadDBManifest = async (ipfs, manifest) => {
-  const dag = await ipfs.object.put(encodeManifest(manifest))
+const uploadDBManifest = async (ipfs, manifest, signature) => {
+  const signedManifest = Object.assign({}, manifest, { signature })
+  const dag = await ipfs.object.put(encodeManifest(signedManifest))
   return dag.toJSON().multihash.toString()
 }
 
@@ -33,7 +35,8 @@ const signDBManifest = async (manifest, identity, identityProvider) => {
   return identityProvider.sign(identity, encodeManifest(manifest))
 }
 
-const verifyDBManifest = async (manifest, signature, identityProvider) => {
+const verifyDBManifest = async (signedManifest, identityProvider) => {
+  const { signature, ...manifest } = signedManifest
   const { owner } = manifest
   return identityProvider.verify(signature, owner, encodeManifest(manifest))
 }

--- a/src/orbit-db-address.js
+++ b/src/orbit-db-address.js
@@ -4,14 +4,13 @@ const path = require('path')
 const multihash = require('multihashes')
 
 class OrbitDBAddress {
-  constructor (root, path, signature) {
+  constructor (root, path) {
     this.root = root
     this.path = path
-    this.signature = signature
   }
 
   toString () {
-    return path.join('/orbitdb', this.root, this.path, this.signature)
+    return path.join('/orbitdb', this.root, this.path)
   }
 
   static isValid (address) {
@@ -42,7 +41,7 @@ class OrbitDBAddress {
       .filter((e, i) => !((i === 0 || i === 1) && address.toString().indexOf('/orbit') === 0 && e === 'orbitdb'))
       .filter(e => e !== '' && e !== ' ')
 
-    return new OrbitDBAddress(parts[0], parts.slice(1, parts.length - 1).join('/'), parts.slice(2, parts.length).join())
+    return new OrbitDBAddress(parts[0], parts.slice(1, parts.length).join('/'))
   }
 }
 


### PR DESCRIPTION
## Description

This PR reverts some changes done to `OrbitDBAddress` and embeds the signature into the object that is uploaded to IPFS instead so store addresses are back to the original length 😉 